### PR TITLE
fix: add workaround for iOS 12 deployment target

### DIFF
--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -34,3 +34,18 @@ target 'App' do
   capacitor_pods
   # Add your Pods here
 end
+
+deployment_target = '12.0'
+
+post_install do |installer|
+    installer.generated_projects.each do |project|
+        project.targets.each do |target|
+            target.build_configurations.each do |config|
+                config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = deployment_target
+            end
+        end
+        project.build_configurations.each do |bc|
+            bc.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = deployment_target
+        end
+    end
+end


### PR DESCRIPTION
If you use latest capacitor/ios, it will fail to compile because of plugins using iOS 11 deployment target.
This workaround forces all plugins to use iOS 12.
Can be deleted after the plugins are updated