### PR TITLE
feat: Add isPluginAvailable checks on some pages

### DIFF
--- a/src/pages/Motion.tsx
+++ b/src/pages/Motion.tsx
@@ -15,15 +15,24 @@ import {
   useIonViewDidEnter,
 } from '@ionic/react';
 import React, { useState } from 'react';
+import { Capacitor } from '@capacitor/core';
 
 const MotionPage: React.FC = () => {
   let accelHandler: PluginListenerHandle;
   let orientationHandler: PluginListenerHandle;
   const [showPermButton, setShowPermButton] = useState(false);
+  const [showButtons, setShowButtons] = useState(true);
 
   useIonViewDidEnter(() => {
-    if (DeviceOrientationEvent !== undefined && typeof DeviceOrientationEvent.requestPermission === 'function') {
-      setShowPermButton(true);
+    if (Capacitor.isPluginAvailable('Motion')) {
+      if (
+        DeviceOrientationEvent !== undefined &&
+        typeof DeviceOrientationEvent.requestPermission === 'function'
+      ) {
+        setShowPermButton(true);
+      }
+    } else {
+      setShowButtons(false);
     }
   });
 
@@ -76,34 +85,42 @@ const MotionPage: React.FC = () => {
       </IonHeader>
       <IonContent>
         <IonList>
-          {showPermButton ? (
-            <IonItem>
-              <IonLabel>iOS 13 Permission</IonLabel>
-              <IonButton expand="block" onClick={requestPermission}>
-                Request Motion Permission
-              </IonButton>
-            </IonItem>
+          {showButtons ? (
+            showPermButton ? (
+              <IonItem>
+                <IonLabel>iOS 13 Permission</IonLabel>
+                <IonButton expand="block" onClick={requestPermission}>
+                  Request Motion Permission
+                </IonButton>
+              </IonItem>
+            ) : (
+              [
+                <IonItem>
+                  <IonLabel>Orientation</IonLabel>
+                  <IonButton expand="block" onClick={listenOrientation}>
+                    Listen Orientation
+                  </IonButton>
+                  <IonButton expand="block" onClick={stopOrientation}>
+                    Stop Orientation
+                  </IonButton>
+                </IonItem>,
+                <IonItem>
+                  <IonLabel>Acceleration</IonLabel>
+                  <IonButton expand="block" onClick={listenAcceleration}>
+                    Listen Acceleration
+                  </IonButton>
+                  <IonButton expand="block" onClick={stopAcceleration}>
+                    Stop Acceleration
+                  </IonButton>
+                </IonItem>,
+              ]
+            )
           ) : (
-            [
-              <IonItem>
-                <IonLabel>Orientation</IonLabel>
-                <IonButton expand="block" onClick={listenOrientation}>
-                  Listen Orientation
-                </IonButton>
-                <IonButton expand="block" onClick={stopOrientation}>
-                  Stop Orientation
-                </IonButton>
-              </IonItem>,
-              <IonItem>
-                <IonLabel>Acceleration</IonLabel>
-                <IonButton expand="block" onClick={listenAcceleration}>
-                  Listen Acceleration
-                </IonButton>
-                <IonButton expand="block" onClick={stopAcceleration}>
-                  Stop Acceleration
-                </IonButton>
-              </IonItem>,
-            ]
+            <IonItem>
+              <IonLabel>
+                Motion plugin not supported on {Capacitor.getPlatform()}
+              </IonLabel>
+            </IonItem>
           )}
         </IonList>
       </IonContent>

--- a/src/pages/StatusBar.tsx
+++ b/src/pages/StatusBar.tsx
@@ -3,6 +3,7 @@ import {
   IonButtons,
   IonContent,
   IonHeader,
+  IonLabel,
   IonPage,
   IonMenuButton,
   IonTitle,
@@ -10,15 +11,21 @@ import {
   useIonViewDidEnter,
 } from '@ionic/react';
 import React, { useState } from 'react';
+import { Capacitor } from '@capacitor/core';
 import { StatusBar, Style } from '@capacitor/status-bar';
 
 const StatusBarPage: React.FC = () => {
   const [statusbarInfoJson, setStatusbarInfoJson] = useState('');
+  const [showButtons, setShowButtons] = useState(true);
 
   useIonViewDidEnter(() => {
-    window.addEventListener('statusTap', function () {
-      console.log('statusbar tapped');
-    });
+    if (Capacitor.isPluginAvailable('StatusBar')) {
+      window.addEventListener('statusTap', function () {
+        console.log('statusbar tapped');
+      });
+    } else {
+      setShowButtons(false);
+    }
   });
 
   const changeStatusBar = async () => {
@@ -87,37 +94,44 @@ const StatusBarPage: React.FC = () => {
         </IonToolbar>
       </IonHeader>
       <IonContent>
-        <IonButton expand="block" onClick={changeStatusBar}>
-          Change StatusBar Style Default
-        </IonButton>
-        <IonButton expand="block" onClick={changeStatusBarLight}>
-          Change StatusBar Style Light
-        </IonButton>
-        <IonButton expand="block" onClick={changeStatusBarDark}>
-          Change StatusBar Style Dark
-        </IonButton>
-        <IonButton expand="block" onClick={showStatusBar}>
-          Show
-        </IonButton>
-        <IonButton expand="block" onClick={hideStatusBar}>
-          Hide
-        </IonButton>
-        <IonButton expand="block" onClick={overlayStatusbar}>
-          overlay Statusbar
-        </IonButton>
-        <IonButton expand="block" onClick={unOverlayStatusbar}>
-          unoverlay Statusbar
-        </IonButton>
-        <IonButton expand="block" onClick={setBackgroundColor}>
-          Set Background Color
-        </IonButton>
-
-        <IonButton expand="block" onClick={getInfo}>
-          get Info
-        </IonButton>
-        <div>
-          <pre>{statusbarInfoJson}</pre>
-        </div>
+        {showButtons ? (
+          [
+            <IonButton expand="block" onClick={changeStatusBar}>
+              Change StatusBar Style Default
+            </IonButton>,
+            <IonButton expand="block" onClick={changeStatusBarLight}>
+              Change StatusBar Style Light
+            </IonButton>,
+            <IonButton expand="block" onClick={changeStatusBarDark}>
+              Change StatusBar Style Dark
+            </IonButton>,
+            <IonButton expand="block" onClick={showStatusBar}>
+              Show
+            </IonButton>,
+            <IonButton expand="block" onClick={hideStatusBar}>
+              Hide
+            </IonButton>,
+            <IonButton expand="block" onClick={overlayStatusbar}>
+              overlay Statusbar
+            </IonButton>,
+            <IonButton expand="block" onClick={unOverlayStatusbar}>
+              unoverlay Statusbar
+            </IonButton>,
+            <IonButton expand="block" onClick={setBackgroundColor}>
+              Set Background Color
+            </IonButton>,
+            <IonButton expand="block" onClick={getInfo}>
+              get Info
+            </IonButton>,
+            <div>
+              <pre>{statusbarInfoJson}</pre>
+            </div>,
+          ]
+        ) : (
+          <IonLabel>
+            StatusBar plugin not supported on {Capacitor.getPlatform()}
+          </IonLabel>
+        )}
       </IonContent>
     </IonPage>
   );

--- a/src/pages/TextZoom.tsx
+++ b/src/pages/TextZoom.tsx
@@ -18,15 +18,21 @@ import {
 } from '@ionic/react';
 import React, { useState } from 'react';
 
+import { Capacitor } from '@capacitor/core';
 import { TextZoom } from '@capacitor/text-zoom';
 import { createEventTargetValueExtractor } from '../utils/dom';
 
 const TextZoomPage: React.FC = () => {
   const [level, setLevel] = useState('1');
+  const [showButtons, setShowButtons] = useState(true);
 
   useIonViewDidEnter(async () => {
-    const { value: level } = await TextZoom.get();
-    setLevel(level.toString());
+    if (Capacitor.isPluginAvailable('TextZoom')) {
+      const { value: level } = await TextZoom.get();
+      setLevel(level.toString());
+    } else {
+      setShowButtons(false);
+    }
   });
 
   const handleLevelInputChange = createEventTargetValueExtractor(setLevel);
@@ -56,32 +62,40 @@ const TextZoomPage: React.FC = () => {
         </IonToolbar>
       </IonHeader>
       <IonContent>
-        <p>The preferred zoom level can be set in the Settings app.</p>
-        <IonGrid>
-          <IonRow>
-            <IonCol>
-              <IonButton onClick={getZoomLevel} expand="block">
-                Get Current Zoom
-              </IonButton>
-            </IonCol>
-          </IonRow>
-          <IonRow>
-            <IonCol>
-              <IonButton onClick={getPreferredZoomLevel} expand="block">
-                Get Preferred Zoom
-              </IonButton>
-            </IonCol>
-          </IonRow>
-        </IonGrid>
-        <IonList>
-          <IonItem>
-            <IonLabel position="stacked">Zoom Level</IonLabel>
-            <IonInput value={level} onInput={handleLevelInputChange} />
-            <IonButton onClick={setZoomLevel} slot="end">
-              Set
-            </IonButton>
-          </IonItem>
-        </IonList>
+        {showButtons ? (
+          [
+            <p>The preferred zoom level can be set in the Settings app.</p>,
+            <IonGrid>
+              <IonRow>
+                <IonCol>
+                  <IonButton onClick={getZoomLevel} expand="block">
+                    Get Current Zoom
+                  </IonButton>
+                </IonCol>
+              </IonRow>
+              <IonRow>
+                <IonCol>
+                  <IonButton onClick={getPreferredZoomLevel} expand="block">
+                    Get Preferred Zoom
+                  </IonButton>
+                </IonCol>
+              </IonRow>
+            </IonGrid>,
+            <IonList>
+              <IonItem>
+                <IonLabel position="stacked">Zoom Level</IonLabel>
+                <IonInput value={level} onInput={handleLevelInputChange} />
+                <IonButton onClick={setZoomLevel} slot="end">
+                  Set
+                </IonButton>
+              </IonItem>
+            </IonList>,
+          ]
+        ) : (
+          <IonLabel>
+            TextZoom plugin not supported on {Capacitor.getPlatform()}
+          </IonLabel>
+        )}
       </IonContent>
     </IonPage>
   );


### PR DESCRIPTION
Added `isPluginAvailable` checks in a few pages to verify that it works as expected.

- In StatusBar page it should show a message that is not available when run on web, on iOS and Android should show buttons.
- In Motion page, it should show buttons on all platforms.
- In TextZoom page it should show a message that is not available when run on web, on iOS and Android should show buttons.

I added the checks on this pages because:
- StatusBar has no web implementation.
- Motion is a web only plugin, but on native it fallbacks to it, so it should be available despite there is no native code.
- TextZoom mix web code and native code on iOS implementation.

