### PR TITLE
Cast as any to avoid typescript errors

### DIFF
--- a/src/pages/Motion.tsx
+++ b/src/pages/Motion.tsx
@@ -17,6 +17,10 @@ import {
 import React, { useState } from 'react';
 import { Capacitor } from '@capacitor/core';
 
+// https://developer.mozilla.org/en-US/docs/Web/API/DeviceOrientationEvent
+//  DeviceOrientationEvent and DeviceMotionEvent will be set as any to avoid typescript errors 
+// when accessing requestPermission
+
 const MotionPage: React.FC = () => {
   let accelHandler: PluginListenerHandle;
   let orientationHandler: PluginListenerHandle;
@@ -27,7 +31,7 @@ const MotionPage: React.FC = () => {
     if (Capacitor.isPluginAvailable('Motion')) {
       if (
         DeviceOrientationEvent !== undefined &&
-        typeof DeviceOrientationEvent.requestPermission === 'function'
+        typeof (DeviceOrientationEvent as any).requestPermission === 'function'
       ) {
         setShowPermButton(true);
       }
@@ -62,7 +66,7 @@ const MotionPage: React.FC = () => {
 
   const requestPermission = async () => {
     try {
-      const result = await DeviceMotionEvent.requestPermission();
+      const result = await (DeviceMotionEvent as any).requestPermission();
       if (result === 'granted') {
         setShowPermButton(false);
       } else {

--- a/src/pages/Motion.tsx
+++ b/src/pages/Motion.tsx
@@ -18,7 +18,7 @@ import React, { useState } from 'react';
 import { Capacitor } from '@capacitor/core';
 
 // https://developer.mozilla.org/en-US/docs/Web/API/DeviceOrientationEvent
-//  DeviceOrientationEvent and DeviceMotionEvent will be set as any to avoid typescript errors 
+// DeviceOrientationEvent and DeviceMotionEvent will be set as any to avoid typescript errors 
 // when accessing requestPermission
 
 const MotionPage: React.FC = () => {


### PR DESCRIPTION
The IDE will show typescript errors on those lines since the API is not ready yet,.
Small fix in case makes sense to avoid confusion
I added a comment on top of the file to explain the cast as any

https://developer.mozilla.org/en-US/docs/Web/API/DeviceOrientationEvent

![image](https://user-images.githubusercontent.com/171174/214017132-daa510c2-0e3c-4c36-837b-4847f1c846c1.png)

![image](https://user-images.githubusercontent.com/171174/214017408-0c442ddb-92d1-4884-addf-b2eb35f2cc15.png)
