### PR TITLE
feat: add test button for unregistering push notifications

### DIFF
--- a/src/components/NotificationsTest.tsx
+++ b/src/components/NotificationsTest.tsx
@@ -70,6 +70,15 @@ export default function NotificationTest({ permissions }: Props) {
     }
   };
 
+  const unregisterPushNotifications = async () => {
+    try {
+      await PushNotifications.register();
+    } catch (e: any) {
+      console.log('unregistering for push notifications failed');
+      console.error(e);
+    }
+  };
+
   useEffect(() => {
     PushNotifications.addListener('registration', token => {
       console.info('Registration token: ', token);
@@ -123,6 +132,9 @@ export default function NotificationTest({ permissions }: Props) {
         </IonButton>
         <IonButton onClick={removeDeliveredNotifications} expand="block">
           Remove All Delivered Notifications
+        </IonButton>
+        <IonButton onClick={unregisterPushNotifications} expand="block">
+          Unregister for Push Notifications
         </IonButton>
       </section>
       <IonList>

--- a/src/pages/PushNotifications.tsx
+++ b/src/pages/PushNotifications.tsx
@@ -1,7 +1,6 @@
 import { PushNotifications } from '@capacitor/push-notifications';
 import {
   IonButtons,
-  IonButton,
   IonContent,
   IonHeader,
   IonPage,
@@ -52,15 +51,6 @@ const PushNotificationsPage: React.FC = () => {
     }
   };
 
-  const unregister = async () => {
-    try {
-      await PushNotifications.unregister()
-    } catch(e: any) {
-      console.log('unregistering for push notifications')
-      console.error(e)
-    }
-  }
-
   useIonViewDidEnter(async () => {
     const hasPermission = await ensurePermissions();
     setHasPermission(hasPermission);
@@ -80,9 +70,6 @@ const PushNotificationsPage: React.FC = () => {
       <IonContent>
         <NotificationsTest permissions={hasPermission} />
         <br />
-        <IonButton onClick={unregister} expand="block">
-          Unregister for Notifications
-        </IonButton>
         <NotificationChannelsTest notificationType="push" />
       </IonContent>
     </IonPage>

--- a/src/pages/PushNotifications.tsx
+++ b/src/pages/PushNotifications.tsx
@@ -1,6 +1,7 @@
 import { PushNotifications } from '@capacitor/push-notifications';
 import {
   IonButtons,
+  IonButton,
   IonContent,
   IonHeader,
   IonPage,
@@ -51,6 +52,15 @@ const PushNotificationsPage: React.FC = () => {
     }
   };
 
+  const unregister = async () => {
+    try {
+      await PushNotifications.unregister()
+    } catch(e: any) {
+      console.log('unregistering for push notifications')
+      console.error(e)
+    }
+  }
+
   useIonViewDidEnter(async () => {
     const hasPermission = await ensurePermissions();
     setHasPermission(hasPermission);
@@ -70,6 +80,9 @@ const PushNotificationsPage: React.FC = () => {
       <IonContent>
         <NotificationsTest permissions={hasPermission} />
         <br />
+        <IonButton onClick={unregister} expand="block">
+          Unregister for Notifications
+        </IonButton>
         <NotificationChannelsTest notificationType="push" />
       </IonContent>
     </IonPage>


### PR DESCRIPTION
Requires ionic-team/capacitor-plugins#1498 to function.

Also, I'm more than happy to take style suggestions - I kinda just slapped a button in there.