### PR TITLE
refactor: remove async from useIonViewDidEnter

### DIFF
--- a/src/pages/LocalNotifications.tsx
+++ b/src/pages/LocalNotifications.tsx
@@ -115,10 +115,14 @@ const LocalNotificationsPage: React.FC = () => {
     };
   }, []);
 
-  useIonViewDidEnter(async () => {
+  useIonViewDidEnter(() => {
+    checkPermissions();
+  });
+
+  const checkPermissions = async () => {
     const permissions = await ensurePermissions();
     setHasPermission(permissions);
-  });
+  }
 
   return (
     <IonPage>

--- a/src/pages/PushNotifications.tsx
+++ b/src/pages/PushNotifications.tsx
@@ -51,11 +51,15 @@ const PushNotificationsPage: React.FC = () => {
     }
   };
 
-  useIonViewDidEnter(async () => {
+  useIonViewDidEnter(() => {
+    checkPermissionsAndRegister();
+  });
+
+  const checkPermissionsAndRegister = async () => {
     const hasPermission = await ensurePermissions();
     setHasPermission(hasPermission);
     await register();
-  });
+  }
 
   return (
     <IonPage>

--- a/src/pages/TextZoom.tsx
+++ b/src/pages/TextZoom.tsx
@@ -26,14 +26,18 @@ const TextZoomPage: React.FC = () => {
   const [level, setLevel] = useState('1');
   const [showButtons, setShowButtons] = useState(true);
 
-  useIonViewDidEnter(async () => {
+  useIonViewDidEnter(() => {
     if (Capacitor.isPluginAvailable('TextZoom')) {
-      const { value: level } = await TextZoom.get();
-      setLevel(level.toString());
+      getInitialZoom();
     } else {
       setShowButtons(false);
     }
   });
+
+  const getInitialZoom = async () => {
+    const { value: level } = await TextZoom.get();
+      setLevel(level.toString());
+  }
 
   const handleLevelInputChange = createEventTargetValueExtractor(setLevel);
 


### PR DESCRIPTION
Apparently it was never supported to use async/await insice `useIonViewDidEnter`, but now the app won't compile with latest ionic version if doing so, so refactor the code to not use async/await.